### PR TITLE
Add glob pattern support to quality runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ npm run dev -- <command>
 npm run dev -- inline-variable "[src/example.ts 5:8-5:18]"
 
 # Quality tools
-npm run quality              # Run all quality checks
+npm run quality -- "src/**/*.ts" "tests/**/*.ts"  # Run quality checks on specific glob patterns
 npm run quality:full         # Run all quality checks with no limit (show all violations)
 
 # Snooze quality alerts (24 hours)

--- a/src/quality-tools/checks/change-frequency-check.ts
+++ b/src/quality-tools/checks/change-frequency-check.ts
@@ -6,10 +6,12 @@ const execAsync = promisify(exec);
 
 export const changeFrequencyCheck: QualityCheck = {
   name: 'changeFrequency',
-  check: async (): Promise<QualityIssue[]> => {
+  check: async (files: string[]): Promise<QualityIssue[]> => {
     const changeIssues = await analyzeChangeFrequency();
     const filteredIssues = await filterRecentlyFixedIssues(changeIssues);
-    return filteredIssues.map(toQualityIssue);
+    return filteredIssues
+      .filter(issue => files.some(file => issue.includes(file)))
+      .map(toQualityIssue);
   },
   getGroupDefinition: (groupKey: string) => {
     if (groupKey === 'changeFrequency') return {

--- a/src/quality-tools/checks/comment-check.ts
+++ b/src/quality-tools/checks/comment-check.ts
@@ -4,9 +4,9 @@ import * as path from 'path';
 
 export const commentCheck: QualityCheck = {
   name: 'comment',
-  check: (sourceDir: string): QualityIssue[] => {
+  check: (files: string[]): QualityIssue[] => {
     const project = new Project();
-    project.addSourceFilesAtPaths(`${sourceDir}/**/*.ts`);
+    project.addSourceFilesAtPaths(files);
     
     return project.getSourceFiles().flatMap(findCommentsInFile);
   },

--- a/src/quality-tools/checks/duplication-check.ts
+++ b/src/quality-tools/checks/duplication-check.ts
@@ -11,7 +11,7 @@ interface ExecError extends Error {
 
 export const duplicationCheck: QualityCheck = {
   name: 'duplication',
-  check: async (): Promise<QualityIssue[]> => {
+  check: async (_files: string[]): Promise<QualityIssue[]> => {
     const issues: QualityIssue[] = [];
     
     await checkSourceCodeDuplication(issues);

--- a/src/quality-tools/checks/feature-envy-check.ts
+++ b/src/quality-tools/checks/feature-envy-check.ts
@@ -5,9 +5,9 @@ import { ImportSymbolExtractor, FeatureEnvyDetector } from './services';
 
 export const featureEnvyCheck: QualityCheck = {
   name: 'featureEnvy',
-  check: (sourceDir: string): QualityIssue[] => {
+  check: (files: string[]): QualityIssue[] => {
     const project = new Project();
-    project.addSourceFilesAtPaths(`${sourceDir}/**/*.ts`);
+    project.addSourceFilesAtPaths(files);
     
     const issues: QualityIssue[] = [];
     const processed = new Set<string>();

--- a/src/quality-tools/checks/file-size-check.ts
+++ b/src/quality-tools/checks/file-size-check.ts
@@ -4,9 +4,9 @@ import * as path from 'path';
 
 export const fileSizeCheck: QualityCheck = {
   name: 'fileSize',
-  check: (sourceDir: string): QualityIssue[] => {
+  check: (files: string[]): QualityIssue[] => {
     const project = new Project();
-    project.addSourceFilesAtPaths(`${sourceDir}/**/*.ts`);
+    project.addSourceFilesAtPaths(files);
     
     return project.getSourceFiles()
       .map(createFileSizeIssue)

--- a/src/quality-tools/checks/function-size-check.ts
+++ b/src/quality-tools/checks/function-size-check.ts
@@ -4,9 +4,9 @@ import * as path from 'path';
 
 export const functionSizeCheck: QualityCheck = {
   name: 'functionSize',
-  check: (sourceDir: string): QualityIssue[] => {
+  check: (files: string[]): QualityIssue[] => {
     const project = new Project();
-    project.addSourceFilesAtPaths(`${sourceDir}/**/*.ts`);
+    project.addSourceFilesAtPaths(files);
     
     return project.getSourceFiles()
       .flatMap(createFunctionSizeIssues)

--- a/src/quality-tools/checks/git-diff-check.ts
+++ b/src/quality-tools/checks/git-diff-check.ts
@@ -9,7 +9,7 @@ let gitDiffResult: QualityIssue[] = [];
 
 export const gitDiffCheck: QualityCheck = {
   name: 'diffSize',
-  check: async (): Promise<QualityIssue[]> => {
+  check: async (_files: string[]): Promise<QualityIssue[]> => {
     if (gitDiffChecked) {
       return [];
     }

--- a/src/quality-tools/checks/incomplete-refactoring-check.ts
+++ b/src/quality-tools/checks/incomplete-refactoring-check.ts
@@ -4,7 +4,7 @@ import { isCheckSnoozed, clearExpiredSnoozes } from '../snooze-tracker';
 
 export const incompleteRefactoringCheck: QualityCheck = {
   name: 'incompleteRefactoring',
-  check: (): QualityIssue[] => {
+  check: (_files: string[]): QualityIssue[] => {
     clearExpiredSnoozes();
     const incompleteRefactorings = getIncompleteRefactorings();
     const activelySnoozedRefactorings = filterSnoozedRefactorings(incompleteRefactorings);

--- a/src/quality-tools/checks/linter-check.ts
+++ b/src/quality-tools/checks/linter-check.ts
@@ -69,9 +69,14 @@ function parseEslintResults(stdout: string): QualityIssue[] {
 
 export const linterCheck: QualityCheck = {
   name: 'linter-check',
-  check: async (_sourceDir: string): Promise<QualityIssue[]> => {
+  check: async (files: string[]): Promise<QualityIssue[]> => {
+    if (files.length === 0) {
+      return [];
+    }
+    
     try {
-      const { stdout, stderr } = await execAsync('npx eslint src tests/integration tests/utils tests/unit --ext .ts --format json');
+      const fileArgs = files.map(f => `'${f}'`).join(' ');
+      const { stdout, stderr } = await execAsync(`npx eslint ${fileArgs} --format json --no-warn-ignored`);
       
       if (stderr && !stderr.includes('warning')) {
         return [{

--- a/src/quality-tools/checks/unused-method-check.ts
+++ b/src/quality-tools/checks/unused-method-check.ts
@@ -17,10 +17,12 @@ interface KnipOutput {
 
 export const unusedMethodCheck: QualityCheck = {
   name: 'unusedMethod',
-  check: async (): Promise<QualityIssue[]> => {
+  check: async (files: string[]): Promise<QualityIssue[]> => {
     try {
       const members = await getUnusedClassMembers();
-      return members.map(toQualityIssue);
+      return members
+        .filter(member => files.includes(member.file))
+        .map(toQualityIssue);
     } catch {
       return [];
     }

--- a/src/quality-tools/glob-resolver.ts
+++ b/src/quality-tools/glob-resolver.ts
@@ -1,0 +1,12 @@
+import { glob } from 'glob';
+import * as fs from 'fs';
+
+export const resolveGlobPatterns = async (patterns: string[]): Promise<string[]> => {
+  const allFiles = await Promise.all(
+    patterns.map(pattern => glob(pattern))
+  );
+  const uniqueFiles = [...new Set(allFiles.flat())];
+  return uniqueFiles.filter(file => 
+    fs.existsSync(file) && file.endsWith('.ts')
+  );
+};

--- a/src/quality-tools/quality-check-interface.ts
+++ b/src/quality-tools/quality-check-interface.ts
@@ -9,7 +9,7 @@ export interface QualityIssue {
 
 export interface QualityCheck {
   name: string;
-  check: (_sourceDir: string) => Promise<QualityIssue[]> | QualityIssue[];
+  check: (_files: string[]) => Promise<QualityIssue[]> | QualityIssue[];
   getGroupDefinition?: (_groupKey: string) => Omit<QualityGroup, 'violations'> | undefined;
 }
 


### PR DESCRIPTION
Enable targeted quality checks on specific files/patterns instead of always running on entire codebase.

Features:
- npm run quality -- "src/commands/*.ts" - Run on specific files
- npm run quality -- "src/**/*.ts" "tests/unit/*.ts" - Multiple patterns
- npm run quality - Default behavior unchanged (src + tests)
- Help text shows glob pattern examples

Benefits:
- Faster quality checks during development
- Perfect for lint-staged integration
- Enables targeted quality analysis

🤖 Generated with [Claude Code](https://claude.ai/code)