### PR TITLE
Fix ESLint no-unused-vars conflict for TypeScript files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,7 @@ module.exports = [
     },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
-      'no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+      'no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -88,7 +88,7 @@ module.exports = [
     },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
-      'no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+      'no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'off', // Allow any in tests for mocking
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',


### PR DESCRIPTION
## Summary
- Disable the base `no-unused-vars` rule for TypeScript files to prevent conflicts with `@typescript-eslint/no-unused-vars`
- This resolves false positives where the base rule incorrectly flags parameters as unused in TypeScript class constructors and methods

## Problem
The ESLint base rule `no-unused-vars` and the TypeScript-specific rule `@typescript-eslint/no-unused-vars` can conflict, causing false positives for parameters that are actually used in TypeScript code.

## Solution
As recommended by the TypeScript ESLint documentation, disable the base rule when using the TypeScript equivalent for better type-aware analysis.

## References
- https://typescript-eslint.io/rules/no-unused-vars/
- ESLint best practices recommend disabling base rules when using TypeScript equivalents

🤖 Generated with [Claude Code](https://claude.ai/code)