### PR TITLE
. t tests for name scoping conflicts

### DIFF
--- a/tests/fixtures/commands/rename/nested-scope-conflict-1.input.ts
+++ b/tests/fixtures/commands/rename/nested-scope-conflict-1.input.ts
@@ -1,0 +1,16 @@
+/**
+ * @description Renaming x to y should cause a name conflict with inner y
+ * @command refakts rename "[nested-scope-conflict-1.input.ts 7:9-7:10]" --to "y"
+ */
+
+function f() {
+  const x = 1;
+  {
+    const y = 2;
+    {
+      return x;
+    }
+  }
+}
+
+expect(f()).toBe(1);

--- a/tests/fixtures/commands/rename/nested-scope-conflict-2.input.ts
+++ b/tests/fixtures/commands/rename/nested-scope-conflict-2.input.ts
@@ -1,0 +1,16 @@
+/**
+ * @description Renaming y to x should cause a name conflict with outer x
+ * @command refakts rename "[nested-scope-conflict-2.input.ts 9:9-9:10]" --to "x"
+ */
+
+function f() {
+  const x = 1;
+  {
+    const y = 2;
+    {
+      return x;
+    }
+  }
+}
+
+expect(f()).toBe(1);


### PR DESCRIPTION
A rename can bring an identifier into conflict with a name at a different scope. #73 