### PR TITLE
Add fixture JSDoc consistency guidelines

### DIFF
--- a/guides/COMMAND_IMPLEMENTATION.md
+++ b/guides/COMMAND_IMPLEMENTATION.md
@@ -240,6 +240,14 @@ tests/fixtures/commands/my-command/
 └── error-handling/
 ```
 
+### Fixture Test JSDoc Consistency
+
+When creating fixture test pairs (`.input.ts` and `.expected.ts`):
+
+- **Copy JSDoc exactly** from `.input.ts` to `.expected.ts` 
+- **Keep coordinates unchanged** - `@command` line numbers must reference the `.input.ts` file location
+- **Maintain identical content** - all JSDoc metadata must match exactly
+
 ### Unit Tests for Service Logic
 ```typescript
 describe('MyDomainService', () => {


### PR DESCRIPTION
## Summary

Adds guidelines to prevent JSDoc inconsistencies between fixture test file pairs (`.input.ts` and `.expected.ts`).

## Background

While working on fixture tests for issue #73 (name conflict detection), Claude made an error by using incorrect line numbers in the JSDoc `@command` annotations of `.expected.ts` files, causing the documentation to reference wrong coordinates compared to the `.input.ts` files.

## Design Decision: Maintain JSDoc Repetition

Although this violates DRY principles, we decided to keep identical JSDoc in both fixture files because the repetition provides significant value to AI agents - each file is self-documenting and can be understood in isolation without requiring cross-file references, which is especially important given RefakTS is built "by AI agents, for AI agents."

## Implementation Approach

The easiest immediate solution is adding clear guidelines to `guides/COMMAND_IMPLEMENTATION.md`. Future automation options could include linting rules to validate JSDoc consistency, pre-commit hooks to check fixture pairs, or programmatic generation of `.expected.ts` files from `.input.ts` + transformation results.

## Changes

- Added concise guidelines under "Fixture Test JSDoc Consistency" section
- Emphasizes copying JSDoc exactly from input to expected files
- Specifies that `@command` coordinates must always reference the input file location