### PR TITLE
Phase 6: Add success messages to commands and fixture output expectation

### DIFF
--- a/src/core/commands/extract-variable-command.ts
+++ b/src/core/commands/extract-variable-command.ts
@@ -25,9 +25,13 @@ export class ExtractVariableCommand implements RefactoringCommand {
     this.validateOptions(options);
     const location = LocationRange.from(options.location as LocationRange);
     this.astService = ASTService.createForFile(file);
-    await this.performExtraction(this.astService.findNodeByLocation(location), options);
+    const count = await this.performExtraction(this.astService.findNodeByLocation(location), options);
     await this.astService.saveSourceFile(this.astService.loadSourceFile(file));
-    return new RefactoringCommandResult();
+    const variableName = options.name as string;
+    const message = options.all
+      ? `Successfully extracted variable '${variableName}' (${count} occurrence${count === 1 ? '' : 's'} replaced)`
+      : `Successfully extracted variable '${variableName}'`;
+    return new RefactoringCommandResult(message);
   }
 
   validateOptions(options: CommandOptions): void {
@@ -43,11 +47,12 @@ export class ExtractVariableCommand implements RefactoringCommand {
     return '\nExamples:\n  refakts extract-variable "[src/file.ts 8:15-8:29]" --name "result"';
   }
 
-  private async performExtraction(targetNode: Node, options: CommandOptions): Promise<void> {
+  private async performExtraction(targetNode: Node, options: CommandOptions): Promise<number> {
     if (options.all) {
-      await this.extractAllOccurrences(targetNode, options.name as string);
+      return await this.extractAllOccurrences(targetNode, options.name as string);
     } else {
       await this.extractSingleOccurrence(targetNode, options.name as string);
+      return 1;
     }
   }
 
@@ -59,12 +64,13 @@ export class ExtractVariableCommand implements RefactoringCommand {
     targetNode.replaceWithText(uniqueName);
   }
 
-  private async extractAllOccurrences(targetNode: Node, variableName: string): Promise<void> {
+  private async extractAllOccurrences(targetNode: Node, variableName: string): Promise<number> {
     this.validateExpressionNode(targetNode);
     const allExpressions = this.expressionMatcher.findAllMatchingExpressions(targetNode);
     this.validateExpressionsFound(allExpressions);
 
     this.extractInEachScope(this.expressionMatcher.groupExpressionsByScope(allExpressions), variableName);
+    return allExpressions.length;
   }
 
   private validateExpressionNode(node: Node): void {

--- a/src/core/commands/rename-command.ts
+++ b/src/core/commands/rename-command.ts
@@ -26,9 +26,9 @@ export class RenameCommand implements RefactoringCommand {
     this.astService = ASTService.createForFile(file);
     this.variableLocator = new VariableLocator(this.astService.getProject());
     this.nameValidator = new VariableNameValidator();
-    await this.performRename(this.astService.findNodeByLocation(location), options.to as string);
+    const result = await this.performRename(this.astService.findNodeByLocation(location), options.to as string);
     await this.astService.saveSourceFile(this.astService.loadSourceFile(file));
-    return new RefactoringCommandResult();
+    return result;
   }
 
   validateOptions(options: CommandOptions): void {
@@ -44,13 +44,22 @@ export class RenameCommand implements RefactoringCommand {
     return '\nExamples:\n  refakts rename "[src/file.ts 5:8-5:18]" --to newName';
   }
 
-  private async performRename(node: Node, newName: string): Promise<void> {
+  private async performRename(node: Node, newName: string): Promise<RefactoringCommandResult> {
     NodeAnalyzer.validateIdentifierNode(node);
-    const sourceFile = node.getSourceFile();
-    const nodeResult = this.findVariableNodesAtPosition(node, sourceFile);
-
+    const nodeResult = this.findVariableNodesAtPosition(node, node.getSourceFile());
     this.validateNewName(nodeResult.declaration, newName);
-    await this.createRenameTransformation(nodeResult, newName).transform(sourceFile);
+    return this.applyRename(nodeResult, nodeResult.variable, newName);
+  }
+
+  private async applyRename(nodeResult: VariableNodeResult, oldName: string, newName: string): Promise<RefactoringCommandResult> {
+    const transformResult = await this.createRenameTransformation(nodeResult, newName).transformWithResult();
+    if (!transformResult.success) {
+      throw new Error(transformResult.message || 'Rename transformation failed');
+    }
+    const count = transformResult.changesCount;
+    return new RefactoringCommandResult(
+      `Successfully renamed '${oldName}' to '${newName}' (${count} occurrence${count === 1 ? '' : 's'} renamed)`
+    );
   }
 
   private findVariableNodesAtPosition(node: Node, sourceFile: SourceFile) {

--- a/src/core/commands/sort-methods-command.ts
+++ b/src/core/commands/sort-methods-command.ts
@@ -22,9 +22,12 @@ export class SortMethodsCommand implements RefactoringCommand {
     this.validateOptions(options);
     const location = LocationRange.from(options.location as LocationRange);
     this.astService = ASTService.createForFile(file);
-    await this.performMethodSorting(this.findTargetClass(this.astService.findNodeByLocation(location)));
+    const targetClass = this.findTargetClass(this.astService.findNodeByLocation(location));
+    const { className, methodCount } = await this.performMethodSorting(targetClass);
     await this.astService.saveSourceFile(this.astService.loadSourceFile(file));
-    return new RefactoringCommandResult();
+    return new RefactoringCommandResult(
+      `Successfully sorted ${methodCount} method${methodCount === 1 ? '' : 's'} in class '${className}'`
+    );
   }
 
   private findTargetClass(targetNode: Node): ClassDeclaration {
@@ -60,11 +63,13 @@ export class SortMethodsCommand implements RefactoringCommand {
     this.consoleOutput = consoleOutput;
   }
 
-  private async performMethodSorting(targetClass: ClassDeclaration): Promise<void> {
+  private async performMethodSorting(targetClass: ClassDeclaration): Promise<{ className: string; methodCount: number }> {
     const methods = this.methodFinder.findMethods(targetClass);
-    if (this.shouldSkipSorting(methods)) return;
-
-    this.reorderMethodsInClass(targetClass, this.getSortedMethods(methods));
+    const className = targetClass.getName() ?? 'unknown';
+    if (!this.shouldSkipSorting(methods)) {
+      this.reorderMethodsInClass(targetClass, this.getSortedMethods(methods));
+    }
+    return { className, methodCount: targetClass.getMethods().length };
   }
   
   private shouldSkipSorting(methods: MethodInfo[]): boolean {

--- a/tests/fixtures/commands/extract-variable/cli-location-format.expected.out
+++ b/tests/fixtures/commands/extract-variable/cli-location-format.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'sum'

--- a/tests/fixtures/commands/extract-variable/complex-expression-first-single-occurence.expected.out
+++ b/tests/fixtures/commands/extract-variable/complex-expression-first-single-occurence.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'upperName'

--- a/tests/fixtures/commands/extract-variable/complex-expression-last-selected.expected.out
+++ b/tests/fixtures/commands/extract-variable/complex-expression-last-selected.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'upperName' (2 occurrences replaced)

--- a/tests/fixtures/commands/extract-variable/complex-expression-last-single-occurence.expected.out
+++ b/tests/fixtures/commands/extract-variable/complex-expression-last-single-occurence.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'upperName'

--- a/tests/fixtures/commands/extract-variable/complex-expression.expected.out
+++ b/tests/fixtures/commands/extract-variable/complex-expression.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'upperName' (2 occurrences replaced)

--- a/tests/fixtures/commands/extract-variable/conditional-block.expected.out
+++ b/tests/fixtures/commands/extract-variable/conditional-block.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'userAge'

--- a/tests/fixtures/commands/extract-variable/extract-variable-holding-function.expected.out
+++ b/tests/fixtures/commands/extract-variable/extract-variable-holding-function.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'toUpperCase' (2 occurrences replaced)

--- a/tests/fixtures/commands/extract-variable/location-simple-expression.expected.out
+++ b/tests/fixtures/commands/extract-variable/location-simple-expression.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'result'

--- a/tests/fixtures/commands/extract-variable/multi-arg-method-call.expected.out
+++ b/tests/fixtures/commands/extract-variable/multi-arg-method-call.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'formattedName' (2 occurrences replaced)

--- a/tests/fixtures/commands/extract-variable/multi-arg-method-reference.expected.out
+++ b/tests/fixtures/commands/extract-variable/multi-arg-method-reference.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'substringMethod' (2 occurrences replaced)

--- a/tests/fixtures/commands/extract-variable/multiple-occurrences.expected.out
+++ b/tests/fixtures/commands/extract-variable/multiple-occurrences.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'product' (3 occurrences replaced)

--- a/tests/fixtures/commands/extract-variable/name-conflict.expected.out
+++ b/tests/fixtures/commands/extract-variable/name-conflict.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'product'

--- a/tests/fixtures/commands/extract-variable/nested-calls.expected.out
+++ b/tests/fixtures/commands/extract-variable/nested-calls.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'sum'

--- a/tests/fixtures/commands/extract-variable/scope-isolation.expected.out
+++ b/tests/fixtures/commands/extract-variable/scope-isolation.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'sum' (2 occurrences replaced)

--- a/tests/fixtures/commands/extract-variable/simple-expression.expected.out
+++ b/tests/fixtures/commands/extract-variable/simple-expression.expected.out
@@ -1,0 +1,1 @@
+Successfully extracted variable 'area'

--- a/tests/fixtures/commands/rename/arrow-function.expected.out
+++ b/tests/fixtures/commands/rename/arrow-function.expected.out
@@ -1,0 +1,1 @@
+Successfully renamed 'x' to 'value' (3 occurrences renamed)

--- a/tests/fixtures/commands/rename/block-scope.expected.out
+++ b/tests/fixtures/commands/rename/block-scope.expected.out
@@ -1,0 +1,1 @@
+Successfully renamed 'temp' to 'temporaryValue' (3 occurrences renamed)

--- a/tests/fixtures/commands/rename/function-argument.expected.out
+++ b/tests/fixtures/commands/rename/function-argument.expected.out
@@ -1,0 +1,1 @@
+Successfully renamed 'oldParam' to 'newParam' (3 occurrences renamed)

--- a/tests/fixtures/commands/rename/location-simple-variable.expected.out
+++ b/tests/fixtures/commands/rename/location-simple-variable.expected.out
@@ -1,0 +1,1 @@
+Successfully renamed 'temp' to 'newName' (2 occurrences renamed)

--- a/tests/fixtures/commands/rename/nested-scopes.expected.out
+++ b/tests/fixtures/commands/rename/nested-scopes.expected.out
@@ -1,0 +1,1 @@
+Successfully renamed 'items' to 'itemList' (5 occurrences renamed)

--- a/tests/fixtures/commands/rename/scope-isolation.expected.out
+++ b/tests/fixtures/commands/rename/scope-isolation.expected.out
@@ -1,0 +1,1 @@
+Successfully renamed 'data' to 'processedData' (2 occurrences renamed)

--- a/tests/fixtures/commands/rename/simple-variable.expected.out
+++ b/tests/fixtures/commands/rename/simple-variable.expected.out
@@ -1,0 +1,1 @@
+Successfully renamed 'oldName' to 'newName' (2 occurrences renamed)

--- a/tests/fixtures/commands/sort-methods/recursive-methods.expected.out
+++ b/tests/fixtures/commands/sort-methods/recursive-methods.expected.out
@@ -1,0 +1,1 @@
+Successfully sorted 2 methods in class 'MathProcessor'

--- a/tests/fixtures/commands/sort-methods/simple-class.expected.out
+++ b/tests/fixtures/commands/sort-methods/simple-class.expected.out
@@ -1,0 +1,1 @@
+Successfully sorted 4 methods in class 'Calculator'


### PR DESCRIPTION
Commands now return descriptive result messages (rename, extract-variable, sort-methods), and fixture .expected.out files capture their console output for regression testing. Also splits performRename to satisfy the 12-line function size limit.